### PR TITLE
Add github action to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+
+  run-tests:
+  
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+        
+    runs-on: ${{ matrix.os }}
+    
+    defaults:
+      run:
+        shell: bash -l {0}
+    
+    steps:
+    
+      - name: check out repository
+        uses: actions/checkout@v2
+          
+      - name: set up conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: testing-env
+          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: true
+          
+      - name: install package dependencies
+        run: |
+          mamba install numpy
+          
+      - name: install package
+        run: |
+          pip install -e .
+          
+      - name: run all tests
+        run: |
+          (cd ./tests && python run_all_tests.py)

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ An evaluator for streamflow time series in Python
 .. image:: https://badge.fury.io/py/hydroeval.svg
    :target: https://pypi.python.org/pypi/hydroeval
    :alt: PyPI Version
-.. image:: https://www.travis-ci.org/ThibHlln/hydroeval.svg?branch=master
-   :target: https://www.travis-ci.org/ThibHlln/hydroeval
-   :alt: Travis CI Build Status
+.. image:: https://img.shields.io/github/workflow/status/ThibHlln/hydroeval/Tests?label=tests
+   :target: https://github.com/ThibHlln/hydroeval/actions/workflows/tests.yml
+   :alt: GitHub Actions Test Workflow Status
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2591217.svg
    :target: https://doi.org/10.5281/zenodo.2591217
    :alt: DOI


### PR DESCRIPTION
Use GitHub action to replace TravisCI for running tests on different Python versions and different OSs.